### PR TITLE
fix: Remove ocid name

### DIFF
--- a/oci_images.tf
+++ b/oci_images.tf
@@ -1,5 +1,5 @@
 #File used only if Stack is a Marketplace Stack
-#Update based on Marketplace Listing - App Install Package - Image ocid
+#Update based on Marketplace Listing - App Install Package - Image Oracle Cloud Identifier
 #Each element is a single image from Marketpalce Catalog. Elements' name in map is arbitrary 
 
 


### PR DESCRIPTION
This resolves stack listing behavior where image ocid comment was not allowing stack validation to pass through. 